### PR TITLE
[♻️Refactor] 관리자만 신고목록을 조회할 수 있도록 수정

### DIFF
--- a/frontend/musta-project/src/components/organisms/Navigation.tsx
+++ b/frontend/musta-project/src/components/organisms/Navigation.tsx
@@ -21,10 +21,9 @@ import userStore from '../../store/user/userStore';
 const pages = [
   ['Home', '/home'],
   ['게시글', '/article'],
-  ['신고 목록', '/reports'], // 임시 링크 (어드민 페이지로 갈 예정)
 ];
 
-const settings = [
+const baseSettings = [
   ['Profile', '/profile'],
   ['Account', '/account'],
   ['Dashboard', '/dashboard'],
@@ -48,6 +47,11 @@ const Navigation = () => {
   const handleOpenUserMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElUser(event.currentTarget);
   };
+
+  // 현재 사용자의 역할을 확인하고 그에 따른 settings 배열을 생성
+  const settings = authStore.userInfo && authStore.userInfo.role.includes('ROLE_ADMIN')
+      ? [...baseSettings, ['신고 목록', '/reports']]
+      : baseSettings;
 
   const handleCloseNavMenu = () => {
     setAnchorElNav(null);


### PR DESCRIPTION
<!--풀리퀘 스트 작성 -->
<!-- 네이밍 방법 [✨Feature] , [📝Docs], [♻️Refactor], [🐛Fix], [🎉Release],   [🏗️Build], [🛠️Project], [✅Test] [🎨Design] 넣고   -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 --> 
- [x] 커밋 메세지 컨벤션 확인
- [x] 기능 수정 시에 테스트 코드 수정확인
- [x] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [x] 풀리퀘스트 네이밍 컨벤션 확인
- [x] 이슈 연동 확인  

## 🔗 이슈 연동
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<!-- 만약 이슈를 닫는 경우 close 부분 작성  --> 
<!-- close #NN -->

Linked Issue Number :  #203 
close   #203 


## 📣 새로 생성된 기능을 설명
 - [x] Navigation의 '신고목록'을 메뉴바로 이동
 - [x] 기존의 메뉴바 구성인 'settings'를 'baseSettings'로 수정하고, 'authStore'에서 role을 받아와 메뉴바 'settings'를 구성하도록 수정


## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->
- 서버에서도 hasRole을 통해 접근 권한 제어를 하고싶었지만, 추후 확장성으로 남겨둠 ( 기존 auth 코드 이해도 issue)